### PR TITLE
不固定baidu_url_submit.path的文件名、去除对原配置文件的url配置的依赖

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -2,6 +2,7 @@ module.exports = function (locals) {
     var log = this.log;
     var config = this.config;
     var count = config.baidu_url_submit.count;
+    var host = config.baidu_url_submit.host;
     var urlsPath = config.baidu_url_submit.path;
 
     log.info("Generating Baidu urls for last " + count + " posts");
@@ -11,7 +12,7 @@ module.exports = function (locals) {
                      .map(function(post) {
                        return {
                          "date": post.date,
-                         "permalink": post.permalink
+                         "permalink": post.permalink.replace(config.url, host)
                        }
                      })
                      .sort(function(a, b) {
@@ -19,7 +20,7 @@ module.exports = function (locals) {
                      })
                      .slice(0, count)
                      .map(function(post) {
-                       return post.permalink
+                       return post.permalink.replace(config.url, host)
                      })
                      .join('\n');
 

--- a/lib/submitter.js
+++ b/lib/submitter.js
@@ -11,7 +11,7 @@ module.exports = function(args) {
     var token = config.baidu_url_submit.token;
 
     var publicDir = this.public_dir;
-    var baiduUrlsFile = pathFn.join(publicDir, 'baidu_urls.txt');
+    var baiduUrlsFile = pathFn.join(publicDir, urlsPath);
     var urls = fs.readFileSync(baiduUrlsFile, 'utf8');
 
     log.info("Submitting urls \n" + urls)


### PR DESCRIPTION
1. 不固定baidu_url_submit.path的文件名
2. 去除对原配置文件的url配置的依赖
    如果Github Pages有域名重定向，可以直接在baidu_url_submit.host中配置重定向之后的域名，而不需要更改原配置文件中的url配置。可以解决和gitment评论系统的冲突。（用的replace这个比较傻的方法将url的值改为了baidu_url_submit.host的值）