### PR TITLE
support submit amp&mip

### DIFF
--- a/lib/submitter.js
+++ b/lib/submitter.js
@@ -9,6 +9,8 @@ module.exports = function(args) {
     var urlsPath = config.baidu_url_submit.path;
     var host = config.baidu_url_submit.host;
     var token = config.baidu_url_submit.token;
+    var amp = config.baidu_url_submit.amp;
+    var mip = config.baidu_url_submit.mip;   
 
     var publicDir = this.public_dir;
     var baiduUrlsFile = pathFn.join(publicDir, 'baidu_urls.txt');
@@ -25,4 +27,26 @@ module.exports = function(args) {
         console.log(this.responseText);
     };
     xhr.send(urls);
+    if(amp){
+        console.log("submit amp ...")
+        var amp_target = target +"&type=amp";
+        var xhr = new XMLHttpRequest();
+        xhr.open('POST', amp_target, false);
+        xhr.setRequestHeader('Content-type', 'text/plain');
+        xhr.onload = function () {
+            console.log(this.responseText);
+        };
+        xhr.send(urls)
+    }
+    if(mip){
+        console.log("submit mip ...")
+        var amp_target = target +"&type=mip";
+        var xhr = new XMLHttpRequest();
+        xhr.open('POST', amp_target, false);
+        xhr.setRequestHeader('Content-type', 'text/plain');
+        xhr.onload = function () {
+            console.log(this.responseText);
+        };
+        xhr.send(urls)
+    }
 };


### PR DESCRIPTION
百度年底新增了提交mip和amp的方式，与原来提交连接的方式一样，只不过多了个type
用了比较简单的方式去做了个控制，可在_config.yml中配置如下：
```yml
## 百度主动提交
baidu_url_submit:
  count: 1 ## 比如 3，代表提交最新的三个链接
  host: xxx.com ## 在百度站长平台中注册的域名
  token: 6666666 ## 请注意这是您的秘钥， 请不要发布在公众仓库里 !
  path: baidu_urls.txt ## 文本文档的地址， 新链接会保存在此文本文档里
  mip: false
  amp: true
```