### PR TITLE
支持熊掌号配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,24 @@
 ![百度主动提交](http://hui-wang.info/2016/10/23/Hexo%E6%8F%92%E4%BB%B6%E4%B9%8B%E7%99%BE%E5%BA%A6%E4%B8%BB%E5%8A%A8%E6%8F%90%E4%BA%A4%E9%93%BE%E6%8E%A5/baidu_urls_submit.png)
 
 [开发动机和使用文档](https://www.hui-wang.info/2016/10/23/Hexo插件之百度主动提交链接/)
+
+# 熊掌号支持
+
+## baidu_url_submit 配置
+```
+baidu_url_submit:
+  count: 1000 ## 提交最新的一个链接
+  host: alili.tech ## 在百度站长平台中注册的域名
+  token: xxxxx ## 请注意这是您的秘钥， 所以请不要把博客源代码发布在公众仓库里!
+  path: baidu_urls.txt ## 文本文档的地址， 新链接会保存在此文本文档里
+  xz_appid: 'xxxxxx' ## 你的熊掌号 appid
+  xz_token: 'xxxxxx' ## 你的熊掌号 token
+  xz_count: 10 ## 从所有的提交的数据当中选取最新的10条,该数量跟你的熊掌号而定
+```
+
+## deploy 配置
+```
+deploy:
+- type: baidu_url_submitter # 百度
+- type: baidu_xz_url_submitter # 百度熊掌号
+```

--- a/index.js
+++ b/index.js
@@ -1,2 +1,3 @@
 hexo.extend.generator.register('baidu_url_generator', require('./lib/generator'));
 hexo.extend.deployer.register('baidu_url_submitter', require('./lib/submitter'));
+hexo.extend.deployer.register('baidu_xz_url_submitter', require('./lib/xz_submitter'));

--- a/lib/xz_submitter.js
+++ b/lib/xz_submitter.js
@@ -1,0 +1,49 @@
+var pathFn = require('path');
+var fs = require('fs');
+var XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
+
+module.exports = function(args) {
+    var log = this.log;
+    var config = this.config;
+
+    var urlsPath = config.baidu_url_submit.path;
+    var xz_appid = config.baidu_url_submit.xz_appid;
+    var xz_token = config.baidu_url_submit.xz_token;
+    var xz_count = config.baidu_url_submit.xz_count;
+
+    var publicDir = this.public_dir;
+    var baiduUrlsFile = pathFn.join(publicDir, 'baidu_urls.txt');
+    var urls = fs.readFileSync(baiduUrlsFile, 'utf8');
+
+    
+
+    // 最新内容提交
+    var new_target = "http://data.zz.baidu.com/urls?appid="+xz_appid+"&token="+xz_token+"&type=realtime"
+
+    // 历史提交
+    var history_target = "http://data.zz.baidu.com/urls?appid="+xz_appid+"&token="+xz_token+"&type=batch"
+    
+    // 最新url,看熊掌号情况而定
+    var new_ursl_arr = urls.split('\n');
+    new_ursl_arr.length = xz_count
+    var new_urls = new_ursl_arr.join('\n')
+    log.info('new urls \n',new_urls)
+
+    sendData(new_target,new_urls,'最新数据提交完成')
+
+    // 提交历史url 每天最多500w条
+    log.info("all urls \n" + urls)
+    sendData(history_target,urls,"历史数据提交完成")
+
+    function sendData(target,urls,message){
+        var xhr = new XMLHttpRequest();
+        xhr.open('POST', target, false);
+        xhr.setRequestHeader('Content-type', 'text/plain');
+        xhr.onload = function () {
+            console.log(this.responseText);
+            if(message){log.info(message)}
+        };
+        xhr.send(urls);
+    }
+
+};


### PR DESCRIPTION
本次修改支持百度熊掌号,
百度熊掌号可以更快的收录网页地址
最新地址最慢24小时收录.

希望可以友链: https://alili.tech